### PR TITLE
Allow to save private key as base64 format

### DIFF
--- a/pkg/controller/cli/config/github_app.go
+++ b/pkg/controller/cli/config/github_app.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/base64"
+
 	"github.com/m-mizutani/octovy/pkg/domain/types"
 	"github.com/urfave/cli/v2"
 )
@@ -8,7 +10,7 @@ import (
 type GitHubApp struct {
 	ID         types.GitHubAppID
 	Secret     types.GitHubAppSecret
-	PrivateKey types.GitHubAppPrivateKey
+	privateKey types.GitHubAppPrivateKey
 }
 
 func (x *GitHubApp) Flags() []cli.Flag {
@@ -33,9 +35,16 @@ func (x *GitHubApp) Flags() []cli.Flag {
 			Name:        "github-app-private-key",
 			Usage:       "GitHub App Private Key",
 			Category:    "GitHub App",
-			Destination: (*string)(&x.PrivateKey),
+			Destination: (*string)(&x.privateKey),
 			EnvVars:     []string{"OCTOVY_GITHUB_APP_PRIVATE_KEY"},
 			Required:    true,
 		},
 	}
+}
+
+func (x *GitHubApp) PrivateKey() types.GitHubAppPrivateKey {
+	if raw, err := base64.StdEncoding.DecodeString(string(x.privateKey)); err == nil {
+		return types.GitHubAppPrivateKey(raw)
+	}
+	return x.privateKey
 }

--- a/pkg/controller/cli/serve/serve.go
+++ b/pkg/controller/cli/serve/serve.go
@@ -85,7 +85,7 @@ func New() *cli.Command {
 				}
 			}
 
-			ghApp, err := gh.New(githubApp.ID, githubApp.PrivateKey)
+			ghApp, err := gh.New(githubApp.ID, githubApp.PrivateKey())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Try to decode base64 first. If succeeded, it returns decoded string. If not, it returns original string