### PR TITLE
Ignore push event if no head commit ID

### DIFF
--- a/pkg/controller/server/github.go
+++ b/pkg/controller/server/github.go
@@ -52,6 +52,11 @@ func refToBranch(v string) string {
 func githubEventToScanInput(event interface{}) *model.ScanGitHubRepoInput {
 	switch ev := event.(type) {
 	case *github.PushEvent:
+		if ev.HeadCommit == nil || ev.HeadCommit.ID == nil {
+			utils.Logger().Warn("ignore push event without head commit", slog.Any("event", ev))
+			return nil
+		}
+
 		return &model.ScanGitHubRepoInput{
 			GitHubMetadata: model.GitHubMetadata{
 				GitHubCommit: model.GitHubCommit{


### PR DESCRIPTION
Some push event has no head commit field and they should be ignored.